### PR TITLE
비밀번호 변경 및 초기화 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 .idea/
 db_dev.mv.db
 db_dev.trace.db
+/resources/application-mail.yml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-mail")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("com.h2database:h2")

--- a/src/main/java/com/back/jsb/domain/user/PasswordForm.java
+++ b/src/main/java/com/back/jsb/domain/user/PasswordForm.java
@@ -1,12 +1,18 @@
 package com.back.jsb.domain.user;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class PasswordForm {
+    @NotBlank(message = "기존 비밀번호를 입력해주세요.")
     private String oldPassword;
+
+    @NotBlank(message = "신규 비밀번호를 입력해주세요.")
     private String password;
-    private String confirmPassword;
+
+    @NotBlank(message = "비밀번호 확인을 입력해주세요.")
+    private String passwordConfirm;
 }

--- a/src/main/java/com/back/jsb/domain/user/PasswordForm.java
+++ b/src/main/java/com/back/jsb/domain/user/PasswordForm.java
@@ -1,0 +1,12 @@
+package com.back.jsb.domain.user;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PasswordForm {
+    private String oldPassword;
+    private String password;
+    private String confirmPassword;
+}

--- a/src/main/java/com/back/jsb/domain/user/PasswordResetForm.java
+++ b/src/main/java/com/back/jsb/domain/user/PasswordResetForm.java
@@ -1,0 +1,12 @@
+package com.back.jsb.domain.user;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PasswordResetForm {
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String username;
+}

--- a/src/main/java/com/back/jsb/domain/user/User.java
+++ b/src/main/java/com/back/jsb/domain/user/User.java
@@ -26,6 +26,9 @@ public class User extends BaseEntity {
     @Column(unique = true, nullable = false)
     private String nickname;
 
+    @Column(unique = true)
+    private String email;
+
     @Column(nullable = false)
     private String role;
 
@@ -34,5 +37,6 @@ public class User extends BaseEntity {
         this.password = form.getPassword();
         this.nickname = form.getNickname();
         this.role = "USER";
+        this.email = form.getEmail();
     }
 }

--- a/src/main/java/com/back/jsb/domain/user/UserController.java
+++ b/src/main/java/com/back/jsb/domain/user/UserController.java
@@ -116,13 +116,8 @@ public class UserController {
             return "/password_reset_form";
         }
 
-        // TODO: 비밀번호 랜덤 생성
-        String newPassword = "0000"; // 임시로 초기화 비밀번호를 1234로 지정
         // 비밀번호 초기화하기
-        userService.changePassword(user, newPassword);
-
-        // 비밀번호 이메일로 보내기
-        userService.sendPasswordEmail(user, newPassword);
+        userService.resetPassword(user);
         
         return "redirect:/user/login";
     }

--- a/src/main/java/com/back/jsb/domain/user/UserController.java
+++ b/src/main/java/com/back/jsb/domain/user/UserController.java
@@ -62,7 +62,7 @@ public class UserController {
     }
 
     @GetMapping("/password") // 비밀번호 변경
-    public String password() {
+    public String password(@ModelAttribute("form") PasswordForm form) {
         return "/password_form";
     }
 }

--- a/src/main/java/com/back/jsb/domain/user/UserController.java
+++ b/src/main/java/com/back/jsb/domain/user/UserController.java
@@ -60,4 +60,9 @@ public class UserController {
         }
         return "/login_form";
     }
+
+    @GetMapping("/password") // 비밀번호 변경
+    public String password() {
+        return "/password_form";
+    }
 }

--- a/src/main/java/com/back/jsb/domain/user/UserController.java
+++ b/src/main/java/com/back/jsb/domain/user/UserController.java
@@ -97,4 +97,33 @@ public class UserController {
 
         return "redirect:/";
     }
+
+    @GetMapping("/password/reset")
+    public String rest(@ModelAttribute("form") PasswordResetForm form) {
+        return "/password_reset_form";
+    }
+    
+    @PostMapping("/password/reset")
+    public String rest(@Valid @ModelAttribute("form") PasswordResetForm form, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "/password_reset_form";
+        }
+
+        User user = userService.findByUsername(form.getUsername());
+
+        if (user == null) {
+            bindingResult.rejectValue("username", "notFindUser", "해당 아이디의 유저는 존재하지 않습니다.");
+            return "/password_reset_form";
+        }
+
+        // TODO: 비밀번호 랜덤 생성
+        String newPassword = "0000"; // 임시로 초기화 비밀번호를 1234로 지정
+        // 비밀번호 초기화하기
+        userService.changePassword(user, newPassword);
+
+        // 비밀번호 이메일로 보내기
+        userService.sendPasswordEmail(user, newPassword);
+        
+        return "redirect:/user/login";
+    }
 }

--- a/src/main/java/com/back/jsb/domain/user/UserCreateForm.java
+++ b/src/main/java/com/back/jsb/domain/user/UserCreateForm.java
@@ -1,5 +1,6 @@
 package com.back.jsb.domain.user;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,4 +24,9 @@ public class UserCreateForm {
 
     @NotBlank(message = "닉네임은 필수 입력입니다.")
     private String nickname;
+
+    @NotBlank(message = "이메일은 필수 입력입니다.")
+    @Email
+    private String email;
+
 }

--- a/src/main/java/com/back/jsb/domain/user/UserService.java
+++ b/src/main/java/com/back/jsb/domain/user/UserService.java
@@ -1,5 +1,6 @@
 package com.back.jsb.domain.user;
 
+import com.back.jsb.global.mail.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MailService mailService;
 
 
     public void register(UserCreateForm form) {
@@ -39,5 +41,11 @@ public class UserService {
     public void changePassword(User user, String password) {
         user.setPassword(passwordEncoder.encode(password));
         userRepository.save(user);
+    }
+
+    public void sendPasswordEmail(User user, String password) {
+        String subject = "초기화된 비밀번호 [%s]".formatted(password);
+        String content = "☺️ 안녕하세요! BeansBuddies 입니다!\n🔑 초기화된 비밀번호는 [%s] 입니다!\n✅ 로그인 후 반드시 비밀번호를 변경해주세요!".formatted(password);
+        mailService.sendTxtEmail(user.getEmail(), subject, content);
     }
 }

--- a/src/main/java/com/back/jsb/domain/user/UserService.java
+++ b/src/main/java/com/back/jsb/domain/user/UserService.java
@@ -1,6 +1,7 @@
 package com.back.jsb.domain.user;
 
 import com.back.jsb.global.mail.MailService;
+import com.back.jsb.global.security.PasswordUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -41,6 +42,12 @@ public class UserService {
     public void changePassword(User user, String password) {
         user.setPassword(passwordEncoder.encode(password));
         userRepository.save(user);
+    }
+
+    public void resetPassword(User user) {
+        String newPassword = PasswordUtil.generateRandomPassword(8);
+        this.changePassword(user, newPassword);
+        this.sendPasswordEmail(user, newPassword);
     }
 
     public void sendPasswordEmail(User user, String password) {

--- a/src/main/java/com/back/jsb/domain/user/UserService.java
+++ b/src/main/java/com/back/jsb/domain/user/UserService.java
@@ -31,4 +31,13 @@ public class UserService {
     public User findByUsername(String username) {
         return userRepository.findByUsername(username).orElse(null);
     }
+
+    public boolean matchPassword(String rawPassword, String encodedPassword) {
+        return passwordEncoder.matches(rawPassword, encodedPassword);
+    }
+
+    public void changePassword(User user, String password) {
+        user.setPassword(passwordEncoder.encode(password));
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/com/back/jsb/global/initData/BaseInitData.java
+++ b/src/main/java/com/back/jsb/global/initData/BaseInitData.java
@@ -32,6 +32,7 @@ public class BaseInitData {
             userForm1.setPassword("user1");
             userForm1.setPasswordConfirm("user1");
             userForm1.setNickname("닉네임1");
+            userForm1.setEmail("user1@test.com");
             userService.register(userForm1);
 
             //사용자2 생성
@@ -40,6 +41,7 @@ public class BaseInitData {
             userForm2.setPassword("user2");
             userForm2.setPasswordConfirm("user2");
             userForm2.setNickname("닉네임2");
+            userForm2.setEmail("user2@test.com");
             userService.register(userForm2);
 
             //User 객체 가져오기

--- a/src/main/java/com/back/jsb/global/mail/MailService.java
+++ b/src/main/java/com/back/jsb/global/mail/MailService.java
@@ -1,0 +1,27 @@
+package com.back.jsb.global.mail;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MailService {
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String formEmail;
+
+    public MailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void sendTxtEmail(String to, String subject, String content) {
+        SimpleMailMessage smm = new SimpleMailMessage();
+        smm.setFrom(formEmail);
+        smm.setTo(to);           // 받는 사람 이메일
+        smm.setSubject(subject); // 제목
+        smm.setText(content);    // 내용
+        mailSender.send(smm);
+    }
+}

--- a/src/main/java/com/back/jsb/global/security/PasswordUtil.java
+++ b/src/main/java/com/back/jsb/global/security/PasswordUtil.java
@@ -1,0 +1,16 @@
+package com.back.jsb.global.security;
+
+import java.security.SecureRandom;
+
+public class PasswordUtil {
+    private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public static String generateRandomPassword(int length) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            sb.append(CHARS.charAt(RANDOM.nextInt(CHARS.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/back/jsb/global/security/PasswordUtil.java
+++ b/src/main/java/com/back/jsb/global/security/PasswordUtil.java
@@ -3,7 +3,7 @@ package com.back.jsb.global.security;
 import java.security.SecureRandom;
 
 public class PasswordUtil {
-    private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
     private static final SecureRandom RANDOM = new SecureRandom();
 
     public static String generateRandomPassword(int length) {

--- a/src/main/java/com/back/jsb/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/jsb/global/security/SecurityConfig.java
@@ -31,7 +31,8 @@ public class SecurityConfig{
                                 "/question/modify/**",
                                 "/answer/write/**",
                                 "/answer/delete/**",
-                                "/answer/modify/**"
+                                "/answer/modify/**",
+                                "/user/password"
                         ).authenticated()
                         .anyRequest().permitAll()
                 )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,9 @@ spring:
         highlight_sql: true
         use_sql_comments: true
 
+  config:
+    import: application-mail.yml
+
 logging:
   level:
     org.hibernate.orm.jdbc.bind: TRACE

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -520,7 +520,8 @@ header nav ul li a:hover {
 }
 
 .user input[type="text"],
-.user input[type="password"] {
+.user input[type="password"],
+.user input[type="email"] {
     width: 100%;
     padding: 12px;
     border-radius: 6px;

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -22,6 +22,9 @@
                 안녕하세요, <span th:text="${#authentication.principal.nickname}"></span>님
             </li>
             <li sec:authorize="isAuthenticated()">
+                <a th:href="@{/user/password}">비밀번호 변경</a>
+            </li>
+            <li sec:authorize="isAuthenticated()">
                 <a th:href="@{/user/logout}">로그아웃</a>
             </li>
 

--- a/src/main/resources/templates/login_form.html
+++ b/src/main/resources/templates/login_form.html
@@ -29,6 +29,10 @@
         <div>
             <button type="submit" class="btn">로그인</button>
         </div>
+
+        <div>
+            <a href="/user/password/reset">비밀번호를 분실했나요?</a>
+        </div>
     </form>
 </div>
 </html>

--- a/src/main/resources/templates/password_form.html
+++ b/src/main/resources/templates/password_form.html
@@ -1,0 +1,35 @@
+<html layout:decorate="~{layout}">
+<div layout:fragment="content" class="page-container user">
+
+  <h1 class="page-title">비밀번호 변경</h1>
+
+  <!-- 회원가입폼 -->
+  <form th:action="@{/user/password}" th:object="${form}" method="post">
+
+    <div>
+      <label for="password">기존 비밀번호</label>
+      <input id="oldPassword" type="password" th:field="*{oldPassword}" />
+      <div th:if="${#fields.hasErrors('oldPassword')}"
+           th:errors="*{oldPassword}" class="field-error"></div>
+    </div>
+
+    <div>
+      <label for="password">신규 비밀번호</label>
+      <input id="password" type="password" th:field="*{password}" />
+      <div th:if="${#fields.hasErrors('password')}"
+           th:errors="*{password}" class="field-error"></div>
+    </div>
+
+    <div>
+      <label for="confirmPassword">비밀번호 확인</label>
+      <input id="confirmPassword" type="password" th:field="*{confirmPassword}" />
+      <div th:if="${#fields.hasErrors('confirmPassword')}"
+           th:errors="*{confirmPassword}" class="field-error"></div>
+    </div>
+
+    <div class="form-actions">
+      <button type="submit" class="btn">변경</button>
+    </div>
+  </form>
+</div>
+</html>

--- a/src/main/resources/templates/password_form.html
+++ b/src/main/resources/templates/password_form.html
@@ -21,10 +21,10 @@
     </div>
 
     <div>
-      <label for="confirmPassword">비밀번호 확인</label>
-      <input id="confirmPassword" type="password" th:field="*{confirmPassword}" />
-      <div th:if="${#fields.hasErrors('confirmPassword')}"
-           th:errors="*{confirmPassword}" class="field-error"></div>
+      <label for="passwordConfirm">비밀번호 확인</label>
+      <input id="passwordConfirm" type="password" th:field="*{passwordConfirm}" />
+      <div th:if="${#fields.hasErrors('passwordConfirm')}"
+           th:errors="*{passwordConfirm}" class="field-error"></div>
     </div>
 
     <div class="form-actions">

--- a/src/main/resources/templates/password_reset_form.html
+++ b/src/main/resources/templates/password_reset_form.html
@@ -1,0 +1,22 @@
+<html layout:decorate="~{layout}">
+<div layout:fragment="content" class="page-container user">
+
+  <h1 class="page-title">비밀번호 변경</h1>
+  <h3>아이디를 입력하여 비밀번호를 초기화 할 수 있습니다.<br>변경된 비밀번호는 회원 정보에 저장된 이메일로 발송됩니다.</h3>
+
+  <!-- 회원가입폼 -->
+  <form th:action="@{/user/password/reset}" th:object="${form}" method="post">
+
+    <div>
+      <label for="username">아이디</label>
+      <input id="username" type="text" th:field="*{username}" />
+      <div th:if="${#fields.hasErrors('username')}"
+           th:errors="*{username}" class="field-error"></div>
+    </div>
+
+    <div class="form-actions">
+      <button type="submit" class="btn">비밀번호 초기화</button>
+    </div>
+  </form>
+</div>
+</html>

--- a/src/main/resources/templates/signup_form.html
+++ b/src/main/resources/templates/signup_form.html
@@ -36,6 +36,13 @@
                  th:errors="*{passwordConfirm}" class="field-error"></div>
         </div>
 
+        <div>
+            <label for="email">이메일</label>
+            <input id="email" type="email" th:field="*{email}" />
+            <div th:if="${#fields.hasErrors('email')}"
+                 th:errors="*{email}" class="field-error"></div>
+        </div>
+
         <div class="form-actions">
             <button type="submit" class="btn">회원가입</button>
         </div>

--- a/src/test/java/com/back/jsb/global/mail/MailServiceTest.java
+++ b/src/test/java/com/back/jsb/global/mail/MailServiceTest.java
@@ -1,0 +1,28 @@
+package com.back.jsb.global.mail;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class MailServiceTest {
+    @Autowired
+    private MailService mailService;
+
+    @Value("${spring.mail.username}")
+    private String testEmail;
+
+    @Test
+    @DisplayName("텍스트 메일 기능 확인")
+    void t1() {
+        mailService.sendTxtEmail(testEmail, "테스트", "테스트 내용");
+    }
+
+    @Test
+    @DisplayName("텍스트에 이모티콘 추가 확인")
+    void t2() {
+        mailService.sendTxtEmail(testEmail, "✅이모티콘", "☺️🔑✅테스트 내용");
+    }
+}


### PR DESCRIPTION
## 개요
사용자의 **비밀번호 수정** 기능과 **비밀번호 초기화** 기능을 구현하였습니다.  
비밀번호 초기화 시에는 회원 가입 시 입력한 이메일로 초기화된 비밀번호가 발송되도록 하였습니다.

---

## 세부 설명

### 1. 비밀번호 수정
<img width="760" height="68" alt="image" src="https://github.com/user-attachments/assets/52c444b8-6832-45db-b389-1cb1c7b7b28b" />

로그인 시 상단 메뉴바에서 비밀번호 변경 항목을 확인할 수 있습니다.



<img width="883" height="499" alt="image" src="https://github.com/user-attachments/assets/0f98d080-f0eb-45c5-ac19-058b2670906d" />

비밀번호 변경 화면에는 다음과 같은 입력창이 있습니다.
- 기존 비밀번호
- 신규 비밀번호
- 신규 비밀번호 확인

입력 후 **변경 버튼**을 누르면 비밀번호가 변경됩니다.  
비밀번호 변경 조건은 다음과 같습니다.

- 기존 비밀번호가 올바르게 입력되어야 함
- 신규 비밀번호는 기존 비밀번호와 동일하지 않아야 함
- 신규 비밀번호 확인 입력란과 동일해야 함.

---

### 2. 비밀번호 초기화
<img width="868" height="429" alt="image" src="https://github.com/user-attachments/assets/e06532fe-57ca-456e-bc39-4762efa4d289" />

로그인 화면 아래의 링크를 통해 비밀번호 초기화 화면으로 들어갈 수 있습니다.


<img width="886" height="370" alt="image" src="https://github.com/user-attachments/assets/e27ab86e-8f45-439b-9fb5-37d715bfc5b5" />

비밀번호 초기화 과정은 다음과 같습니다.

1. 초기화 화면에서 계정 아이디 입력
2. 존재하지 않는 계정일 경우 오류 반환
3. 정상 계정일 경우 비밀번호 초기화 진행
4. 변경된 비밀번호가 계정 이메일로 발송됨

<img width="349" height="252" alt="image" src="https://github.com/user-attachments/assets/27eea808-113f-4116-8203-f78b47e78b91" />

발송된 이메일은 위의 사진과 같습니다.

---

## 기타 변경 사항 및 참고 사항

### User Entity 수정
- User Entity에 `email` 속성을 추가하였습니다.
- `initData`에서도 User 생성 시 이메일을 넣도록 수정하였습니다.

### SMTP 설정
비밀번호 초기화 기능 구현을 위해 **Naver SMTP**를 사용하였습니다.  
이를 위한 설정은 `application-mail.yml` 파일에 작성되며, 보안 상 해당 파일은 깃허브에 업로드하지 않았습니다.  
아래 예시를 참고하여 직접 작성해야 합니다.


```YAML
spring:                           # 예시에서는 네이버 SMTP 사용중
  mail:
    host: smtp.naver.com          # 네이버 SMTP 서버 주소
    port: 465                     # 네이버 SMTP 포트 번호
    username: xxxxxxx@naver.com    # 네이버 이메일
    password: xxxxxxxxxxx          # 네이버 비밀번호
    properties:
      mail:
        smtp:
          auth: true              # 사용자 인증 여부
          ssl:
            enable: true
            trust: smtp.naver.com
```

관련 참고 링크:  
- [[Java] NAVER 메일 SMTP 환경 설정 방법](https://adjh54.tistory.com/596)

<img width="802" height="197" alt="image" src="https://github.com/user-attachments/assets/4ea8c105-54bd-4d36-bb5e-799e07729048" />


> ⚠️ **주의:**  
> `yml` 파일의 `spring.mail.password`는 네이버 계정 비밀번호가 아닌,  
> POP3/SMTP 사용 설정 시 발급할 수 있는 **전용 어플리케이션 비밀번호**를 사용해야 합니다.